### PR TITLE
Refine live demo task view and styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -134,7 +134,8 @@
     .CodeMirror-lines { padding:10px; }
     .cm-tag { color:#fff; border-radius:10px; padding:1px 5px; line-height: normal; display:inline-block; }
 
-    #notePanel { display:flex; flex-direction:column; }
+    #notePanel { display:flex; flex-direction:column; height:420px; }
+    #previewPanel { height:420px; overflow:auto; }
     #editorWrap { flex:1; min-height:360px; }
 
     /* .rendered-note {  } */
@@ -405,8 +406,8 @@ Document music that helps you focus:
         const due = (clean.match(/\ud83d\udcc5\s*([0-9]{4}-[0-9]{2}-[0-9]{2})/)||[])[1] || (clean.match(/\b(202[4-9]-[01]\d-[0-3]\d)\b/)||[])[1] || '';
         const url = (clean.match(/https?:\/\/\S+/)||[])[0] || '';
         const textContent = clean
-          .replace(/^[-*]\s*\[[x\s]\]\s*/i,'')
-          .replace(/^[-*]\s*/,'')
+          .replace(/^[-+*]\s*\[[x\s]\]\s*/i,'')
+          .replace(/^[-+*]\s*/,'')
           .replace(/#[A-Za-z0-9_-]+/g,'')
           .replace(/\ud83d\udcc5\s*[0-9\/-]+/g,'')
           .replace(url,'')
@@ -425,30 +426,36 @@ Document music that helps you focus:
         tags:n.tags,
         due:n.due,
         url:n.url,
-        view:n.tags.includes('music') ? 'music' : 'task',
+        view:n.tags.includes('music') ? 'music' : (n.tags.some(t=>t==='payment' || t==='pay') ? 'transaction' : 'task'),
         source:name,
         children:n.children
       }));
     }
 
     function currentItems(){
-      const base = collectFromNote(currentNote, cm.getValue());
-      if(includePadEl?.checked){
-        const others = Object.keys(NOTES).filter(n=>n!==currentNote).flatMap(n=>collectFromNote(n, NOTES[n]));
-        return base.concat(others);
-      }
-      return base;
+      const items = Object.keys(NOTES).flatMap(n=>collectFromNote(n, n===currentNote ? cm.getValue() : NOTES[n]));
+      return items;
     }
 
-    function tagColor(str){
-      let h = 0;
-      for (let i = 0; i < str.length; i++) h = str.charCodeAt(i) + ((h << 5) - h);
-      return `hsl(${h % 360},70%,60%)`;
+    const TAG_COLORS = {
+      todo:   { bg:'#4b5563', fg:'#ffffff' },
+      urgent: { bg:'#ef4444', fg:'#ffffff' },
+      music:  { bg:'#6366f1', fg:'#ffffff' },
+      payment:{ bg:'#10b981', fg:'#ffffff' },
+      pay:    { bg:'#10b981', fg:'#ffffff' },
+      'check-in':{ bg:'#0ea5e9', fg:'#ffffff' },
+      iot:    { bg:'#0ea5e9', fg:'#ffffff' },
+      chatgpt:{ bg:'#8b5cf6', fg:'#ffffff' }
+    };
+
+    function tagStyles(str){
+      return TAG_COLORS[str] || { bg:'#94a3b8', fg:'#ffffff' };
     }
 
     function badge(tag){
       const clean = tag.replace('#','');
-      return `<span class="badge" style="background:${tagColor(clean)};">${tag}</span>`;
+      const {bg,fg} = tagStyles(clean);
+      return `<span class="badge" style="background:${bg};color:${fg};">${tag}</span>`;
     }
 
     function tableHTML(title, items){
@@ -462,26 +469,34 @@ Document music that helps you focus:
       const tags = cm.getWrapperElement().querySelectorAll('.cm-tag');
       tags.forEach(el=>{
         const clean = el.textContent.replace('#','');
-        el.style.background = tagColor(clean);
+        const {bg,fg} = tagStyles(clean);
+        el.style.background = bg;
+        el.style.color = fg;
+      });
+    }
+
+    function styleEditorBullets(){
+      const bullets = cm.getWrapperElement().querySelectorAll('.cm-formatting-list');
+      bullets.forEach(el=>{
+        const ch = el.textContent.trim().charAt(0);
+        if(ch === '+') el.style.color = '#3b82f6';
+        else if(ch === '*') el.style.color = '#ef4444';
+        else el.style.color = 'var(--text-normal)';
       });
     }
 
     function matchHeights(){
-      const notePanel = document.getElementById('notePanel');
-      const previewPanel = document.getElementById('previewPanel');
       const editorWrap = document.getElementById('editorWrap');
-      if(notePanel && previewPanel && editorWrap){
-        notePanel.style.height = previewPanel.offsetHeight + 'px';
-        cm.setSize(null, editorWrap.clientHeight);
-      }
+      if(editorWrap) cm.setSize(null, editorWrap.clientHeight);
     }
 
     function render(){
       if(!containerEl) return;
       const items = currentItems();
-      const todos = items.filter(i=>i.view === 'task');
+      const todos = items.filter(i=>i.view === 'task' && i.tags.some(t=>t==='todo' || t==='urgent'));
+      const transactions = items.filter(i=>i.view === 'transaction');
       const music = items.filter(i=>i.view === 'music');
-      containerEl.innerHTML = tableHTML('Todos', todos) + tableHTML('Music', music);
+      containerEl.innerHTML = tableHTML('Todos', todos) + tableHTML('Transactions', transactions) + tableHTML('Music', music);
       containerEl.querySelectorAll('tr.item').forEach(row=>{
         row.addEventListener('click',()=>{
           const next = row.nextElementSibling;
@@ -492,6 +507,7 @@ Document music that helps you focus:
         a.addEventListener('click',e=>{ e.preventDefault(); e.stopPropagation(); loadNote(a.dataset.note); });
       });
       styleEditorTags();
+      styleEditorBullets();
       matchHeights();
     }
 


### PR DESCRIPTION
## Summary
- color-code bullets (+ blue, * red) and add tag color map for predictable styling
- show stable todo dashboard filtering to `todo`/`urgent`, include transactions, and support fixed note panel height
- aggregate note items across tabs so lists stay consistent

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2615b67ec8332b6267ab36888c781