### PR TITLE
Add Bun backend with SQLite and Docker deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+data/
+*.sqlite

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM oven/bun:1 AS base
+WORKDIR /app
+COPY package.json ./
+RUN bun install
+COPY . .
+EXPOSE 3000
+CMD ["bun", "server.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3.8'
+services:
+  app:
+    build: .
+    ports:
+      - "3000:3000"
+    volumes:
+      - data:/app/data
+volumes:
+  data:

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "obsidian-plus-landing",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "start": "bun server.js"
+  },
+  "dependencies": {}
+}

--- a/script.js
+++ b/script.js
@@ -757,3 +757,31 @@ This page is dedicated to a specific project, it's not part of the daily notes. 
     
     // Initial render
     loadNote(currentNote);
+
+    // Email signup
+    document.querySelectorAll('.download-form').forEach(form => {
+      form.addEventListener('submit', async (ev) => {
+        ev.preventDefault();
+        const input = form.querySelector('input[type="email"]');
+        const email = input.value.trim();
+        if (!email) return;
+        try {
+          const res = await fetch('/api/subscribe', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ email })
+          });
+          if (res.ok) {
+            const data = await res.json();
+            const msg = document.createElement('div');
+            msg.className = 'sub';
+            msg.textContent = data.status === 'duplicate' ? 'You are already on the list.' : 'Thanks! Check your inbox soon.';
+            form.replaceWith(msg);
+          } else {
+            alert('Something went wrong. Please try again later.');
+          }
+        } catch (err) {
+          alert('Network error. Please try again later.');
+        }
+      });
+    });

--- a/server.js
+++ b/server.js
@@ -1,0 +1,66 @@
+import { Database } from "bun:sqlite";
+import { mkdirSync } from "node:fs";
+
+mkdirSync("data", { recursive: true });
+const db = new Database("data/emails.sqlite");
+db.run(
+  "CREATE TABLE IF NOT EXISTS emails (id INTEGER PRIMARY KEY AUTOINCREMENT, email TEXT UNIQUE, created_at TEXT)"
+);
+
+const insertStmt = db.prepare(
+  "INSERT INTO emails (email, created_at) VALUES (?, datetime('now'))"
+);
+
+const port = parseInt(process.env.PORT || "3000", 10);
+
+const server = Bun.serve({
+  port,
+  async fetch(req) {
+    const url = new URL(req.url);
+
+    if (req.method === "POST" && url.pathname === "/api/subscribe") {
+      try {
+        const { email } = await req.json();
+        const normalized = String(email || "").trim().toLowerCase();
+        if (!normalized) {
+          return new Response(
+            JSON.stringify({ error: "invalid email" }),
+            { status: 400, headers: { "Content-Type": "application/json" } }
+          );
+        }
+        try {
+          insertStmt.run(normalized);
+          return new Response(
+            JSON.stringify({ status: "ok" }),
+            { headers: { "Content-Type": "application/json" } }
+          );
+        } catch (err) {
+          if (String(err).includes("UNIQUE")) {
+            return new Response(
+              JSON.stringify({ status: "duplicate" }),
+              { headers: { "Content-Type": "application/json" } }
+            );
+          }
+          return new Response(
+            JSON.stringify({ error: "db error" }),
+            { status: 500, headers: { "Content-Type": "application/json" } }
+          );
+        }
+      } catch {
+        return new Response(
+          JSON.stringify({ error: "invalid request" }),
+          { status: 400, headers: { "Content-Type": "application/json" } }
+        );
+      }
+    }
+
+    let filePath = url.pathname === "/" ? "/index.html" : url.pathname;
+    try {
+      return new Response(Bun.file(`.${filePath}`));
+    } catch {
+      return new Response("Not found", { status: 404 });
+    }
+  },
+});
+
+console.log(`Server running at http://localhost:${port}`);


### PR DESCRIPTION
## Summary
- add Bun-powered server that stores submitted emails in SQLite with dedupe logic
- wire download form to POST to the new backend
- add Dockerfile and docker-compose for running the landing page in a container

## Testing
- `PORT=4000 bun server.js` then `curl -s -X POST http://localhost:4000/api/subscribe -H 'Content-Type: application/json' -d '{"email":"alice@example.com"}'`
- `curl -s -X POST http://localhost:4000/api/subscribe -H 'Content-Type: application/json' -d '{"email":"alice@example.com"}'`


------
https://chatgpt.com/codex/tasks/task_e_68a417d057ec83328d2273b1e46406de