### PR TITLE
chore: update demo labels and checkbox spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -126,7 +126,10 @@
         <div class="demo-wrap scenario scenario-dashboard" style="align-items:start;">
           <!-- LEFT: Note editor -->
           <div id="notePanel" class="card panel">
-            <div style="font-weight:700;font-size:16px;">Notes (type here)</div>
+            <div style="font-weight:700;font-size:16px;display:flex;align-items:center;gap:6px;">
+              <svg viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg" style="width:16px;height:16px;"><path d="M128 10L30 74v108l98 64 98-64V74L128 10Z" fill="currentColor"/></svg>
+              <span>Your Obsidian<span style="color:var(--accent)">+</span> Notebook</span>
+            </div>
             <div class="note-tabs">
               <button class="note-tab active" data-note="Daily Notes">Daily Notes</button>
               <button class="note-tab" data-note="Transaction Log">Transaction Log</button>

--- a/style.css
+++ b/style.css
@@ -235,7 +235,7 @@
   height:16px;
   cursor:pointer;
   position:absolute;
-  transform:translate(3px,-21px);
+  transform:translate(5px,-21px);
   z-index:10;
   border:1px solid var(--text-normal);
   border-radius:4px;


### PR DESCRIPTION
## Summary
- rename scenario 1 notebook to "Your Obsidian+ Notebook" with branded styling
- nudge Alice/Bob scenario checkboxes 2px to the right for better alignment

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a528374b74833285c6bd5c9a2b3be4