### PR TITLE
Add SEO and social meta tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,12 +11,15 @@
   <meta property="og:title" content="Obsidian+ — Programmable Productivity, Your Way" />
   <meta property="og:description" content="A programmable Obsidian plugin that turns your vault into a living system. See live demos, real use cases, and grab a starter vault pre‑configured in minutes." />
   <meta property="og:image" content="https://obsidianpl.us/preview.png" />
+  <meta property="og:image:alt" content="Screenshot of Obsidian+ plugin interface" />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://obsidianpl.us/" />
+  <meta property="og:site_name" content="Obsidian+" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Obsidian+ — Programmable Productivity, Your Way" />
   <meta name="twitter:description" content="A programmable Obsidian plugin that turns your vault into a living system. See live demos, real use cases, and grab a starter vault pre‑configured in minutes." />
   <meta name="twitter:image" content="https://obsidianpl.us/preview.png" />
+  <meta name="twitter:image:alt" content="Screenshot of Obsidian+ plugin interface" />
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 256 256'><path fill='%235960f1' d='M128 10 30 74v108l98 64 98-64V74z'/></svg>">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.5/codemirror.min.css">
   <link rel="stylesheet" href="style.css">

--- a/index.html
+++ b/index.html
@@ -5,6 +5,18 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Obsidian+ — Programmable Productivity, Your Way</title>
   <meta name="description" content="A programmable Obsidian plugin that turns your vault into a living system. See live demos, real use cases, and grab a starter vault pre‑configured in minutes." />
+  <meta name="keywords" content="Obsidian plugin, productivity, markdown, automation" />
+  <meta name="robots" content="index, follow" />
+  <link rel="canonical" href="https://obsidianpl.us/" />
+  <meta property="og:title" content="Obsidian+ — Programmable Productivity, Your Way" />
+  <meta property="og:description" content="A programmable Obsidian plugin that turns your vault into a living system. See live demos, real use cases, and grab a starter vault pre‑configured in minutes." />
+  <meta property="og:image" content="https://obsidianpl.us/preview.png" />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://obsidianpl.us/" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Obsidian+ — Programmable Productivity, Your Way" />
+  <meta name="twitter:description" content="A programmable Obsidian plugin that turns your vault into a living system. See live demos, real use cases, and grab a starter vault pre‑configured in minutes." />
+  <meta name="twitter:image" content="https://obsidianpl.us/preview.png" />
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 256 256'><path fill='%235960f1' d='M128 10 30 74v108l98 64 98-64V74z'/></svg>">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.5/codemirror.min.css">
   <link rel="stylesheet" href="style.css">

--- a/server.js
+++ b/server.js
@@ -54,6 +54,12 @@ const server = Bun.serve({
       }
     }
 
+    if (req.method === "GET" && url.pathname === "/preview.png") {
+      return new Response(Bun.file("./preview.png"), {
+        headers: { "Content-Type": "image/png" },
+      });
+    }
+
     let filePath = url.pathname === "/" ? "/index.html" : url.pathname;
     try {
       return new Response(Bun.file(`.${filePath}`));


### PR DESCRIPTION
## Summary
- enhance landing page head with SEO keywords, robots, and canonical link
- add Open Graph and Twitter card metadata for richer sharing previews
- point canonical and social preview URLs to new obsidianpl.us domain

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a6afa80abc8332b65d4dedffa3e7b4